### PR TITLE
Update diffusers docs - ensure latest version of required libraries

### DIFF
--- a/docs/flux2_dev_hf.md
+++ b/docs/flux2_dev_hf.md
@@ -2,10 +2,11 @@
 
 ## Getting started 
 
-Install diffusers from `main` 
+Install diffusers from `main` and upgrade your `transformers`, `accelerate` and `bitsandbytes` dependencies to latest
 
 ```sh
 pip install git+https://github.com/huggingface/diffusers.git
+pip install --upgrade transformers accelerate bitsandbytes
 ```
 
 After accepting the gating on the [FLUX.2-dev repository](https://huggingface.co/black-forest-labs/FLUX.2-dev), login with Hugging Face on your terminal


### PR DESCRIPTION
Users are having issues due to outdated dependencies #6  , which can be mitigated by informing them to upgrade as we do in this PR 