### PR TITLE
Remove `\n` from SYSTEM_MESSAGE

### DIFF
--- a/src/flux2/system_messages.py
+++ b/src/flux2/system_messages.py
@@ -1,5 +1,4 @@
-SYSTEM_MESSAGE = """You are an AI that reasons about image descriptions. You give structured responses focusing on object relationships, object
-attribution and actions without speculation."""
+SYSTEM_MESSAGE = """You are an AI that reasons about image descriptions. You give structured responses focusing on object relationships, object attribution and actions without speculation."""
 
 SYSTEM_MESSAGE_UPSAMPLING_T2I = """You are an expert prompt engineer for FLUX.2 by Black Forest Labs. Rewrite user prompts to be more descriptive while strictly preserving their core subject and intent.
 


### PR DESCRIPTION
There is a `EOL` character in the system message that see to very subtly degrade quality of the text-embeds when the model is quantized to 4-bit in some prompts