### PR TITLE
fix(sampling): gate denoise pred trim on img_cond_seq, not always-non-None ids (#27)

### DIFF
--- a/src/flux2/sampling.py
+++ b/src/flux2/sampling.py
@@ -299,7 +299,11 @@ def denoise(
             ctx_ids=txt_ids,
             guidance=guidance_vec,
         )
-        if img_input_ids is not None:
+        # Trim off the conditioning sequence we concatenated above.
+        # `img_input_ids` is always non-None here (img_ids is required),
+        # so the previous check was a tautology — gate on the actual
+        # signal that we concatenated, matching denoise_cached below.
+        if img_cond_seq is not None:
             pred = pred[:, : img.shape[1]]
 
         img = img + (t_prev - t_curr) * pred

--- a/src/flux2/sampling.py
+++ b/src/flux2/sampling.py
@@ -301,7 +301,7 @@ def denoise(
         )
         # Trim off the conditioning sequence we concatenated above.
         # `img_input_ids` is always non-None here (img_ids is required),
-        # so the previous check was a tautology — gate on the actual
+        # so the previous check was a tautology, gate on the actual
         # signal that we concatenated, matching denoise_cached below.
         if img_cond_seq is not None:
             pred = pred[:, : img.shape[1]]
@@ -324,8 +324,8 @@ def denoise_cached(
 ):
     """Denoise with KV caching for reference image tokens.
 
-    Step 0: model.forward_kv_extract() — full pass with ref tokens, extracts KV cache.
-    Steps 1+: model.forward_kv_cached() — uses cached ref KV, no ref tokens in input.
+    Step 0: model.forward_kv_extract(), full pass with ref tokens, extracts KV cache.
+    Steps 1+: model.forward_kv_cached(), uses cached ref KV, no ref tokens in input.
     """
     guidance_vec = torch.full((img.shape[0],), guidance, device=img.device, dtype=img.dtype)
 


### PR DESCRIPTION
## Summary

Fixes #27. ``denoise`` had ``if img_input_ids is not None:`` to gate the post-prediction sequence trim. ``img_input_ids`` is initialised from ``img_ids`` which is a required (non-Optional) ``Tensor``, the condition was therefore always true. The intended gate is whether we concatenated the conditioning sequence onto the input, i.e. ``img_cond_seq is not None``, exactly what ``denoise_cached`` already uses on line 401.

## Behaviour

Equivalent in practice: when ``img_cond_seq`` is ``None`` no concatenation happens, ``pred.shape[1] == img.shape[1]``, and the slice ``pred[:, : img.shape[1]]`` is a no-op. The fix corrects intent and removes a misleading tautology so the branch matches its mirror in ``denoise_cached``.

## Test plan

- [x] AST parse of ``src/flux2/sampling.py`` is clean
- [x] ``img_cond_seq=None`` path: ``pred[:, :img.shape[1]]`` would be a no-op even without the gate, so disabling it changes nothing
- [x] ``img_cond_seq is not None`` path: trim still runs, identical to before