### PR TITLE
fix: correct condition check in denoise() to match denoise_cfg()

### DIFF
--- a/src/flux2/sampling.py
+++ b/src/flux2/sampling.py
@@ -299,7 +299,7 @@ def denoise(
             ctx_ids=txt_ids,
             guidance=guidance_vec,
         )
-        if img_input_ids is not None:
+        if img_cond_seq is not None:
             pred = pred[:, : img.shape[1]]
 
         img = img + (t_prev - t_curr) * pred


### PR DESCRIPTION
## Summary

- Fix incorrect condition `if img_input_ids is not None` → `if img_cond_seq is not None` in the `denoise()` function
- `img_input_ids` is always assigned (from `img_ids`), so the check is always `True` regardless of whether conditioning was applied
- This aligns `denoise()` with the existing correct pattern in `denoise_cfg()` (line 401)

## Context

The prediction slicing (`pred[:, :img.shape[1]]`) should only happen when image conditioning tokens were concatenated to the input. Currently, the wrong variable is checked — `img_input_ids` (always not None) instead of `img_cond_seq` (None when no conditioning is used).

This is a no-op bug in practice (slicing to the same length when no concat happened), but it's incorrect in intent and could mask issues if the model output shape ever differs.

Fixes #27

## Test plan

- [x] Verified `denoise_cfg()` already uses the correct pattern (`if img_cond_seq is not None:` at line 401)
- [x] Verified the fix is semantically equivalent for the conditioning case (both paths slice identically)
- [x] Verified no behavioral change for the non-conditioning case (slice is a no-op either way)