### PR TITLE
Enable CPU fallback for Qwen3 text encoder and noise generation

### DIFF
--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -281,7 +281,7 @@ def main(
     ), f"{model_name} is not available, choose from {FLUX2_MODEL_INFO.keys()}"
 
     model_info = FLUX2_MODEL_INFO[model_name]
-    torch_device = torch.device("cuda")
+    torch_device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
     text_encoder = load_text_encoder(model_name, device=torch_device)
     if "klein" in model_name:
@@ -579,8 +579,8 @@ def main(
 
                 # Create noise
                 shape = (1, 128, height // 16, width // 16)
-                generator = torch.Generator(device="cuda").manual_seed(seed)
-                randn = torch.randn(shape, generator=generator, dtype=torch.bfloat16, device="cuda")
+                generator = torch.Generator(device=str(torch_device)).manual_seed(seed)
+                randn = torch.randn(shape, generator=generator, dtype=torch.bfloat16, device=str(torch_device))
                 x, x_ids = batched_prc_img(randn)
 
                 timesteps = get_schedule(cfg.num_steps, x.shape[1])

--- a/src/flux2/text_encoder.py
+++ b/src/flux2/text_encoder.py
@@ -373,7 +373,7 @@ class Qwen3Embedder(nn.Module):
 
         self.model = AutoModelForCausalLM.from_pretrained(
             model_spec,
-            torch_dtype=None,
+            torch_dtype=torch.bfloat16,
             device_map=str(device),
         )
 
@@ -433,4 +433,4 @@ def load_mistral_small_embedder(device: str | torch.device = "cuda") -> Mistral3
 
 
 def load_qwen3_embedder(variant: str, device: str | torch.device = "cuda"):
-    return Qwen3Embedder(model_spec=f"Qwen/Qwen3-{variant}-FP8", device=device)
+    return Qwen3Embedder(model_spec=f"Qwen/Qwen3-{variant}", device=device)


### PR DESCRIPTION
## Summary

All FLUX.2 klein variants were hardcoded to FP8-quantized Qwen3 checkpoints and CUDA literals, blocking CPU-only inference.

- **text_encoder.py**: load_qwen3_embedder loads Qwen/Qwen3-{variant} (BF16) instead of -FP8. Qwen3Embedder forces torch_dtype=torch.bfloat16.
- **scripts/cli.py**: torch_device uses torch.cuda.is_available() fallback. Noise generator and randn respect torch_device.

## Why

CPU-only environments hit: No GPU or XPU found. A GPU or XPU is needed for FP8 quantization. This unblocks CPU inference and testing with standard BF16 weights.

## Test plan

- [x] Run cli.py on CPU-only machine with Qwen/Qwen3-4B in HF cache
- [x] Confirm GPU path still works (bfloat16 is valid on CUDA)
- [x] Verify cuda.is_available() guard does not break GPU selection

Generated with Claude Code